### PR TITLE
Added grouping of TEMPO

### DIFF
--- a/Metar.php
+++ b/Metar.php
@@ -447,6 +447,7 @@ class Metar extends \stdClass {
   public $nosig = false;
   public $runway_conditions = array();
   public $remarks;
+  public $tempo;
 
   function __construct ($report = null) {
     if ($report) {
@@ -558,6 +559,12 @@ class Metar extends \stdClass {
       if ($token == 'RMK') {
         $this->remarks = implode(' ', $tokens);
         $tokens = array();
+      }
+      
+      // Read temporary group
+      if ($token == 'TEMPO') {
+      	$this->tempo = implode(' ', $tokens);
+      	$tokens = array();
       }
     }
 


### PR DESCRIPTION
For now this works the same as remarks, but it would probably be better
as its own class with time from, time to and a new set of weather
conditions of its own. 

Here is an example METAR from EHAM:

> EHAM 212055Z 34009KT 300V020 5000 BR FEW005 SCT006 BKN007 19/19 Q1016 TEMPO SCT007

The SCT007 at the end came up as 700 feet scattered in the cloud layers rather than a forecast component for the next two hours.
